### PR TITLE
Fix: Support Namespaced paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,3 @@ gem "puma"
 gem "sqlite3"
 
 gem "sprockets-rails"
-
-# Start debugger with binding.b [https://github.com/ruby/debug]
-# gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    better_mailer_previews (1.0.03)
+    better_mailer_previews (1.0.1)
       rails (>= 5.0.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    better_mailer_previews (0.2.20)
-      rails (>= 7.1.2)
+    better_mailer_previews (1.0.03)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -82,7 +82,7 @@ GEM
       mutex_m
       tzinfo (~> 2.0)
     base64 (0.2.0)
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.5)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
@@ -95,8 +95,8 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.9.1)
+    io-console (0.7.1)
+    irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
     loofah (2.22.0)
@@ -111,7 +111,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    net-imap (0.4.7)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -120,7 +120,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.6.1)
+    nio4r (2.7.0)
     nokogiri (1.15.5-arm64-darwin)
       racc (~> 1.4)
     psych (5.1.1.1)
@@ -166,7 +166,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.1.0)
-    rdoc (6.6.0)
+    rdoc (6.6.2)
       psych (>= 4.0.0)
     reline (0.4.1)
       io-console (~> 0.5)

--- a/app/helpers/better_mailer_previews/application_helper.rb
+++ b/app/helpers/better_mailer_previews/application_helper.rb
@@ -1,13 +1,17 @@
 module BetterMailerPreviews
   module ApplicationHelper
 
-    # For generating mailer preview link names on mailers/index
+    # For generating mailer preview link names on mailers/index,
+    # including namespaced methods.
     #
     # input: "/rails/mailers/invoice_mailer/saas"
     # output: "Preview InvoiceMailer.SaaS →"
     #
     def preview_text_for_url(url)
-      pretty_mailer_preview_name = url.split("/")[-2...].map { |segment| segment.split("_").map(&:capitalize).join }.join(".")
+      camelized = url.split("/")[3...].map { |element| element.camelize }
+      last_element = camelized.pop
+      pretty_mailer_preview_name = camelized.join("/") + "." + last_element
+
       return "Preview #{pretty_mailer_preview_name} →"
     end
 
@@ -18,7 +22,7 @@ module BetterMailerPreviews
     #
     def preview_path_for_url(url)
       mounted_engine_path = BetterMailerPreviews::Engine.routes.find_script_name({})
-      url.split("/")[-2...].join("/").prepend("#{mounted_engine_path}/")
+      url.split("/")[3..].join("/").prepend("#{mounted_engine_path}/")
     end
   end
 end

--- a/app/views/better_mailer_previews/mailers/show.html.erb
+++ b/app/views/better_mailer_previews/mailers/show.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full flex justify-between items-end">
-  <h1 class="text-5xl font-medium tracking-tighter"><%= @mailer_name.titleize %> — <%= @email_type.titleize %></h1>
+  <h1 class="text-5xl font-medium tracking-tighter"><%= @mailer_path.titleize %> — <%= @email_type.titleize %></h1>
   <div class="">
-    <%= form_with url: send_mailer_email_path(mailer_name: @mailer_name, email_type: @email_type),
+    <%= form_with url: send_mailer_email_path(mailer_path: @mailer_path, email_type: @email_type),
                   method: :post,
                   local: true,
                   class: "flex items-end gap-x-2" do |form| %>
@@ -22,7 +22,7 @@
       <div class="hidden sm:block shrink-0 mr-2 h-4 w-4 bg-gray-600 rounded-full"></div>
       <div class="hidden sm:block shrink-0 mr-2 h-4 w-4 bg-gray-600 rounded-full"></div>
       <div class="flex-grow flex items-center justify-center sm:ml-6 sm:mr-24 py-2 px-4 bg-gray-600 rounded-full leading-5 text-sm text-gray-200 text-center truncate">
-        <div class="truncate"><span class="font-medium text-gray-100">Mailer Preview</span> — <%= "#{@mailer_name}/#{@email_type}" %></div>
+        <div class="truncate"><span class="font-medium text-gray-100">Mailer Preview</span> — <%= "#{@mailer_path}/#{@email_type}" %></div>
       </div>
     </div>
     <div class="bg-gray-950 px-2 rounded-b-lg pb-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 BetterMailerPreviews::Engine.routes.draw do
-  root to: 'mailers#index'
+  root to: "mailers#index"
 
-  get '/:mailer_name/:email_type', to: 'mailers#show', as: :mailer_preview
-  post '/:mailer_name/:email_type/send', to: 'mailers#send_email', as: :send_mailer_email
+  # Wildcard routes to handle namespaced mailers
+  get "/*mailer_path/:email_type", to: "mailers#show", as: :mailer_preview
+  post "/*mailer_path/:email_type/send", to: "mailers#send_email", as: :send_mailer_email
 end

--- a/lib/better_mailer_previews/version.rb
+++ b/lib/better_mailer_previews/version.rb
@@ -1,3 +1,3 @@
 module BetterMailerPreviews
-  VERSION = "1.0.0"
+  VERSION = "1.0.03"
 end

--- a/lib/better_mailer_previews/version.rb
+++ b/lib/better_mailer_previews/version.rb
@@ -1,3 +1,3 @@
 module BetterMailerPreviews
-  VERSION = "1.0.03"
+  VERSION = "1.0.1"
 end

--- a/test/helpers/better_mailer_previews/application_helper_test.rb
+++ b/test/helpers/better_mailer_previews/application_helper_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+module BetterMailerPreviews
+  class ApplicationHelperTest < ActionView::TestCase
+    include ApplicationHelper
+
+    class PreviewTextForURL < ActionView::TestCase
+      test "generates correct preview text for URL" do
+        url = "/rails/mailers/invoice_mailer/saas"
+        expected = "Preview InvoiceMailer.Saas →"
+
+        assert_equal expected, preview_text_for_url(url)
+      end
+
+      test "generates correct preview text for namespaced URL" do
+        url = "/rails/mailers/test/test_mailer/github_test"
+        expected = "Preview Test/TestMailer.GithubTest →"
+
+        assert_equal expected, preview_text_for_url(url)
+      end
+    end
+
+    class PreviewPathForURL < ActionView::TestCase
+      test "generates correct preview path for URL" do
+        url = "/rails/mailers/invoice_mailer/saas"
+        expected = "/better_mailer_previews/invoice_mailer/saas"
+
+        assert_equal expected, preview_path_for_url(url)
+      end
+
+      test "generates correct preview path for namespaced URL" do
+        url = "/rails/mailers/test/test_mailer/github_test"
+        expected = "/better_mailer_previews/test/test_mailer/github_test"
+
+        assert_equal expected, preview_path_for_url(url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for previewing and sending mailer previews that live under a namespace path, ie: 
- `previews/user/user_mailer_preview.rb`

This should be handy for people who namespace mailers to make them more specific, like a `user` and `admin` namespace. 

Resolves: https://github.com/harrison-broadbent/better_mailer_previews/issues/8