### PR TITLE
Explicitly load ApplicationHelper in ApplicationController

### DIFF
--- a/app/controllers/better_mailer_previews/application_controller.rb
+++ b/app/controllers/better_mailer_previews/application_controller.rb
@@ -1,4 +1,5 @@
 module BetterMailerPreviews
   class ApplicationController < ActionController::Base
+    helper BetterMailerPreviews::ApplicationHelper
   end
 end

--- a/app/controllers/better_mailer_previews/mailers_controller.rb
+++ b/app/controllers/better_mailer_previews/mailers_controller.rb
@@ -1,5 +1,5 @@
 module BetterMailerPreviews
-  class MailersController < ActionController::Base
+  class MailersController < BetterMailerPreviews::ApplicationController
     layout "better_mailer_previews/application"
 
     def index


### PR DESCRIPTION
This should fix #18. I noticed that the main controller was not inheriting from ApplicationController, so I also changed that. Let me know if that shouldn't be the case, and I can move the `helper` call to the other controller.